### PR TITLE
完成了服务器端渲染的开发环境搭建

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,11 +108,13 @@ if(isDev){
 }
 ```
 
-### [webpack 配置react-hot-loader热加载局部更新](https://blog.csdn.net/huangpb123/article/details/78556652)
+### [webpack 配置react-hot-loader热更替](https://blog.csdn.net/huangpb123/article/details/78556652)
 
 webpack-dev-server 已经是热加载了，能做到只要代码修改了页面也自动更新了，为什么在 react 项目还要安装 react-hot-loader 呢？其实这两者的更新是有区别的，webpack-dev-server 的热加载是开发人员修改了代码，代码经过打包，重新刷新了整个页面。而 react-hot-loader 不会刷新整个页面，它只替换了修改的代码，做到了页面的局部刷新。但它需要依赖 webpack 的 HotModuleReplacement 热加载插件。
 
-## 服务端渲染配置
+## 服务端渲染
+
+### 服务端渲染配置(生产环境)
 
 1 首先把需要服务端渲染的内容，放到独立的文件内，如本项目的client-entry.js
 
@@ -144,7 +146,105 @@ res.send(template.replace('<!--app-->', appString))
 app.use('/public', express.static(path.join(__dirname, '../dist')))  
 ```
 
-## package.json
+### 服务端渲染 开发环境的搭建(热更替)
+
+#### 主要知识点
+
++ [webpack({/*配置对象*/}, (err, stats) => {/* do something */})](https://www.webpackjs.com/api/node/#webpack-)
+
++ [Compiler 实例](https://www.webpackjs.com/api/node/#compiler-%E5%AE%9E%E4%BE%8B-compiler-instance-)：如果你不向 webpack 执行函数传入回调函数，就会得到一个 webpack Compiler 实例
+    + .run(callback)
+    + [.watch(watchOptions, handler)](https://www.webpackjs.com/api/node/#%E7%9B%91%E5%90%AC-watching-)
+
++ [自定义文件系统](https://www.webpackjs.com/api/node/#%E8%87%AA%E5%AE%9A%E4%B9%89%E6%96%87%E4%BB%B6%E7%B3%BB%E7%BB%9F-custom-file-systems-)
+    + 可以使用 memory-fs 替换默认的 outputFileSystem，以将文件写入到内存中，而不是写入到磁盘
+
++ [http-proxy-middleware](https://www.jianshu.com/p/a248b146c55a)：因为开发环境中我们通过webpack-dev-server开启服务器进行开发，打包后生产的文件保存在内存中，不像生产环境下有生产的dist目录 ，所以我们就不能像生产环境中 通过 express.static 去处理静态文件的请求， 但是开发环境下的 js等文件可以通过url请求，所以通过 proxy的代理，我们一样能够请求到这些 静态文件
+
+#### server/util/dev-static.js
+
+```js
+const axios = require('axios')
+const webpack = require('webpack')
+const path = require('path')
+const MemoryFs = require('memory-fs')
+const ReactSSR = require('react-dom/server')
+const proxy = require('http-proxy-middleware')
+
+// 用于接收 bundle
+let serverBundle
+
+// server端的 webpack 配置文件
+const webpack_server_config = require('../../build/webpack.config.server')
+
+//如果你不向 webpack 执行函数传入回调函数，就会得到一个 webpack Compiler 实例。你可以通过它手动触发 webpack 执行器，或者是让它执行构建并监听变更
+const serverCompiler = webpack(webpack_server_config)
+
+const mfs = new MemoryFs()
+//使用 memory-fs 替换默认的 outputFileSystem，以将文件写入到内存中，而不是写入到磁盘
+serverCompiler.outputFileSystem = mfs
+
+//调用 watch 方法会触发 webpack 执行器，但之后会监听变更 一旦 webpack 检测到文件变更，就会重新执行编译。该方法返回一个 Watching 实例(它会暴露一个 .close(callback) 方法。调用该方法将会结束监听：)
+const watching = serverCompiler.watch({
+    // watchOptions 示例
+    aggregateTimeout: 300,
+    poll: undefined
+}, (err, stats/*以通过它获取到代码编译过程中的有用信息*/) => {
+    if(err) throw err
+    //以 JSON 对象形式返回编译信息
+    stats = stats.toJson()
+    //打印❌ 信息
+    stats.errors.forEach(err => console.error(err))
+    //打印⚠️ 信息
+    stats.warnings.forEach(warn => console.warn(warn))
+
+    const output = webpack_server_config.output
+    // server-entry.js 打包后的 完整路径
+    const bundlePath = path.join(output.path, output.filename)
+
+    // 读取 打包后的文件，但是 返回的是 string 类型
+    const bundle = mfs.readFileSync(bundlePath, 'utf8')
+
+    // 将webpack打包后生成的字符串 转化成 模块
+    const Module = module.constructor
+    const m = new Module()
+    m._compile(bundle, 'server-entry.js')
+    serverBundle = m.exports.default
+});
+
+
+//请求index.html 的内容
+const getTemplate = () => {
+    return new Promise((resolve, reject) => {
+        // webpack-dev-server 打包后的文件保存在 内存中 ，通过url去访问index.html
+        axios.get('http://localhost:8887/public/index.html')
+            .then(res => {
+                resolve(res.data)
+            })
+            .catch(err => {
+                reject(err)
+            })
+    })
+}
+
+
+module.exports = function (app) {
+
+    //因为 开发环境下通过webpack-dev-server打包 不生成dist目录(保存在内存中) 所以只能将 静态文件的请求 做 代理 的 处理
+    app.use('/public', proxy({
+        target: 'http://localhost:8887'
+    }))
+
+    app.get('*', (req, res) => {
+        getTemplate().then(template => {
+            const content = ReactSSR.renderToString(serverBundle)
+            res.send(template.replace('<!--app-->', content))
+        })
+    })
+}
+```
+
+## package.json中 用到的 包
 
 ### rimraf
 
@@ -155,3 +255,21 @@ app.use('/public', express.static(path.join(__dirname, '../dist')))
 
     这个迷你的包(cross-env)能够提供一个设置环境变量的scripts，让你能够以unix方式设置环境变量，然后在windows上也能兼容运行。解决跨平台设置NODE_ENV的问题
     cross-env NODE_ENV=development
+
+### [memory-fs](https://www.webpackjs.com/api/node/#%E8%87%AA%E5%AE%9A%E4%B9%89%E6%96%87%E4%BB%B6%E7%B3%BB%E7%BB%9F-custom-file-systems-)
+
+    在内存中读写文件， nodejs 的fs模块是在硬盘上读写文件
+
+### [http-proxy-middleware](https://www.jianshu.com/p/a248b146c55a)
+
+    用于把请求代理转发到其他服务器的中间件。
+    ```js
+    var express = require('express');
+    var proxy = require('http-proxy-middleware');
+
+    var app = express();
+    //使发到3000端口的/api请求转发到了3001端口。即请求http://localhost:3000/api相当于请求http://localhost:3001/api
+    app.use('/api', proxy({target: 'http://localhost:3001/', changeOrigin: true}));
+    app.listen(3000);
+    ```
+

--- a/client/App.jsx
+++ b/client/App.jsx
@@ -3,7 +3,7 @@ import React, { Component } from 'react';
 export default class App extends Component {
     render(){
         return (
-            <div>This is app222</div>
+            <div>This is app123</div>
         )
     }
 };

--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
     "build:client": "webpack --config build/webpack.config.client.js",
     "build:server": "webpack --config build/webpack.config.server.js",
     "build": "npm run clear && npm run build:client && npm run build:server",
-    "start": "node server/server.js",
-    "dev:client": "cross-env NODE_ENV=development webpack-dev-server --config build/webpack.config.client.js"
+    "dev:client": "cross-env NODE_ENV=development webpack-dev-server --config build/webpack.config.client.js",
+    "dev:server": "cross-env NODE_ENV=development node server/server.js"
   },
   "author": "dsying",
   "license": "ISC",
@@ -20,6 +20,8 @@
     "babel-loader": "^8.0.5",
     "cross-env": "^5.2.0",
     "html-webpack-plugin": "^3.2.0",
+    "http-proxy-middleware": "^0.19.1",
+    "memory-fs": "^0.4.1",
     "react-hot-loader": "^4.5.3",
     "rimraf": "^2.6.3",
     "webpack": "^4.28.1",
@@ -27,6 +29,7 @@
     "webpack-dev-server": "^3.1.14"
   },
   "dependencies": {
+    "axios": "^0.18.0",
     "express": "^4.16.4",
     "react": "^16.7.0",
     "react-dom": "^16.7.0"

--- a/server/server.js
+++ b/server/server.js
@@ -2,19 +2,36 @@ const express = require('express')
 const ReactSSR = require('react-dom/server')
 const fs = require('fs')
 const path = require('path')
-//注意后面的.default, 因为我们在server-entry.js中 是 export default <App />
-const serverEntry = require('../dist/server-entry').default
+
 
 const app = express()
-const template = fs.readFileSync(path.join(__dirname, '../dist/index.html'), 'utf8')
-console.log(serverEntry);
 
-//所有 /public 的url 请求的都是静态文件， 这里用到的就是 webpack的 output中的 publicPath属性
-app.use('/public', express.static(path.join(__dirname, '../dist')))
+const isDev = process.env.NODE_ENV === 'development'
 
-app.get('*', (req, res) => {
-    const appString = ReactSSR.renderToString(serverEntry)
-    res.send(template.replace('<!--app-->', appString))
-})
+
+/**
+ * 只有在production 生产环境下 我们的项目目录下才会有打包生成的dist目录
+ * 在development 开发环境下 由于使用了 webpack-dev-server， 打包后的文件 存放在内存中，所以要区分处理
+ */
+if(!isDev){
+    // --->production
+    //注意后面的.default, 因为我们在server-entry.js中 是 export default <App />
+    const serverEntry = require('../dist/server-entry').default
+    const template = fs.readFileSync(path.join(__dirname, '../dist/index.html'), 'utf8')
+    console.log(serverEntry);
+
+    //所有 /public 的url 请求的都是静态文件， 这里用到的就是 webpack的 output中的 publicPath属性
+    app.use('/public', express.static(path.join(__dirname, '../dist')))
+
+    app.get('*', (req, res) => {
+        const appString = ReactSSR.renderToString(serverEntry)
+        res.send(template.replace('<!--app-->', appString))
+    })
+}else{
+    // --->development
+    const devStatic = require('./util/dev-static.js')
+    devStatic(app)
+}
+
 
 app.listen(3333, () => console.log('server is starting on port 3333'))

--- a/server/util/dev-static.js
+++ b/server/util/dev-static.js
@@ -1,0 +1,78 @@
+const axios = require('axios')
+const webpack = require('webpack')
+const path = require('path')
+const MemoryFs = require('memory-fs')
+const ReactSSR = require('react-dom/server')
+const proxy = require('http-proxy-middleware')
+
+// 用于接收 bundle
+let serverBundle
+
+// server端的 webpack 配置文件
+const webpack_server_config = require('../../build/webpack.config.server')
+
+//如果你不向 webpack 执行函数传入回调函数，就会得到一个 webpack Compiler 实例。你可以通过它手动触发 webpack 执行器，或者是让它执行构建并监听变更
+const serverCompiler = webpack(webpack_server_config)
+
+const mfs = new MemoryFs()
+//使用 memory-fs 替换默认的 outputFileSystem，以将文件写入到内存中，而不是写入到磁盘
+serverCompiler.outputFileSystem = mfs
+
+//调用 watch 方法会触发 webpack 执行器，但之后会监听变更 一旦 webpack 检测到文件变更，就会重新执行编译。该方法返回一个 Watching 实例(它会暴露一个 .close(callback) 方法。调用该方法将会结束监听：)
+const watching = serverCompiler.watch({
+    // watchOptions 示例
+    aggregateTimeout: 300,
+    poll: undefined
+}, (err, stats/*以通过它获取到代码编译过程中的有用信息*/) => {
+    if(err) throw err
+    //以 JSON 对象形式返回编译信息
+    stats = stats.toJson()
+    //打印❌ 信息
+    stats.errors.forEach(err => console.error(err))
+    //打印⚠️ 信息
+    stats.warnings.forEach(warn => console.warn(warn))
+
+    const output = webpack_server_config.output
+    // server-entry.js 打包后的 完整路径
+    const bundlePath = path.join(output.path, output.filename)
+
+    // 读取 打包后的文件，但是 返回的是 string 类型
+    const bundle = mfs.readFileSync(bundlePath, 'utf8')
+
+    // 将webpack打包后生成的字符串 转化成 模块
+    const Module = module.constructor
+    const m = new Module()
+    m._compile(bundle, 'server-entry.js')
+    serverBundle = m.exports.default
+});
+
+
+
+const getTemplate = () => {
+    return new Promise((resolve, reject) => {
+        // webpack-dev-server 打包后的文件保存在 内存中 ，通过url去访问index.html
+        axios.get('http://localhost:8887/public/index.html')
+            .then(res => {
+                resolve(res.data)
+            })
+            .catch(err => {
+                reject(err)
+            })
+    })
+}
+
+
+module.exports = function (app) {
+
+    //因为 开发环境下通过webpack-dev-server打包 不生成dist目录(保存在内存中) 所以只能将 静态文件的请求 做 代理 的 处理
+    app.use('/public', proxy({
+        target: 'http://localhost:8887'
+    }))
+
+    app.get('*', (req, res) => {
+        getTemplate().then(template => {
+            const content = ReactSSR.renderToString(serverBundle)
+            res.send(template.replace('<!--app-->', content))
+        })
+    })
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -844,6 +844,13 @@ atob@^2.1.1:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/atob/-/atob-2.1.2.tgz#6d9517eb9e030d2436666651e86bd9f6f13533c9"
 
+axios@^0.18.0:
+  version "0.18.0"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.18.0.tgz#32d53e4851efdc0a11993b6cd000789d70c05102"
+  dependencies:
+    follow-redirects "^1.3.0"
+    is-buffer "^1.1.5"
+
 babel-loader@^8.0.5:
   version "8.0.5"
   resolved "https://registry.yarnpkg.com/babel-loader/-/babel-loader-8.0.5.tgz#225322d7509c2157655840bba52e46b6c2f2fe33"
@@ -1875,7 +1882,7 @@ flush-write-stream@^1.0.0:
     inherits "^2.0.1"
     readable-stream "^2.0.4"
 
-follow-redirects@^1.0.0:
+follow-redirects@^1.0.0, follow-redirects@^1.3.0:
   version "1.6.1"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.6.1.tgz#514973c44b5757368bad8bddfe52f81f015c94cb"
   dependencies:
@@ -2180,6 +2187,15 @@ http-parser-js@>=0.4.0:
   version "0.5.0"
   resolved "https://registry.yarnpkg.com/http-parser-js/-/http-parser-js-0.5.0.tgz#d65edbede84349d0dc30320815a15d39cc3cbbd8"
 
+http-proxy-middleware@^0.19.1:
+  version "0.19.1"
+  resolved "https://registry.yarnpkg.com/http-proxy-middleware/-/http-proxy-middleware-0.19.1.tgz#183c7dc4aa1479150306498c210cdaf96080a43a"
+  dependencies:
+    http-proxy "^1.17.0"
+    is-glob "^4.0.0"
+    lodash "^4.17.11"
+    micromatch "^3.1.10"
+
 http-proxy-middleware@~0.18.0:
   version "0.18.0"
   resolved "https://registry.yarnpkg.com/http-proxy-middleware/-/http-proxy-middleware-0.18.0.tgz#0987e6bb5a5606e5a69168d8f967a87f15dd8aab"
@@ -2189,7 +2205,7 @@ http-proxy-middleware@~0.18.0:
     lodash "^4.17.5"
     micromatch "^3.1.9"
 
-http-proxy@^1.16.2:
+http-proxy@^1.16.2, http-proxy@^1.17.0:
   version "1.17.0"
   resolved "https://registry.yarnpkg.com/http-proxy/-/http-proxy-1.17.0.tgz#7ad38494658f84605e2f6db4436df410f4e5be9a"
   dependencies:
@@ -2580,7 +2596,7 @@ lodash.merge@^4.6.1:
   version "4.6.1"
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.1.tgz#adc25d9cb99b9391c59624f379fbba60d7111d54"
 
-lodash@^4.17.10, lodash@^4.17.3, lodash@^4.17.5:
+lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.3, lodash@^4.17.5:
   version "4.17.11"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
 
@@ -2646,7 +2662,7 @@ mem@^4.0.0:
     mimic-fn "^1.0.0"
     p-is-promise "^1.1.0"
 
-memory-fs@^0.4.0, memory-fs@~0.4.1:
+memory-fs@^0.4.0, memory-fs@^0.4.1, memory-fs@~0.4.1:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/memory-fs/-/memory-fs-0.4.1.tgz#3a9a20b8462523e447cfbc7e8bb80ed667bfc552"
   dependencies:


### PR DESCRIPTION
1 服务器端渲染时 根据 NODE_DEV 区分 生产和开发环境(因为生产环境打包后有dist目录，而开发环境下因为使用了webpack-dev-server缘故，打包文件保存在内存中）

2 因为开发环境下，打包文件存在于内存中，所以需要调用 webpack的API 通过代码去 执行 打包操作

3 通过http-proxy-middleware 代理 js等静态文件